### PR TITLE
If the service locator does not implement the injector or releaser, use a

### DIFF
--- a/src/Engine/MvcTurbine.Web/Config/Engine.cs
+++ b/src/Engine/MvcTurbine.Web/Config/Engine.cs
@@ -87,16 +87,18 @@
 				locator.Register(() => locator);
 
 				// To provide DI support for IServiceReleaser
-				if (locator is IServiceReleaser) {
-					locator.Register(() => locator as IServiceReleaser);
-				}
+			    if (locator is IServiceReleaser)
+			        locator.Register(() => locator as IServiceReleaser);
+			    else
+			        locator.Register<IServiceReleaser, EmptyServiceReleaser>();
 
-				// To provide DI support for IServiceInjector
-				if (locator is IServiceInjector) {
-					locator.Register(() => locator as IServiceInjector);
-				}
-				
-				foreach (var item in engineRegistrations) {
+			    // To provide DI support for IServiceInjector
+			    if (locator is IServiceInjector)
+			        locator.Register(() => locator as IServiceInjector);
+			    else
+			        locator.Register<IServiceInjector, EmptyServiceInjector>();
+
+			    foreach (var item in engineRegistrations) {
 					locator.Register(item.Key, item.Value);
 				}
 

--- a/src/Engine/MvcTurbine/ComponentModel/EmptyServiceInjector.cs
+++ b/src/Engine/MvcTurbine/ComponentModel/EmptyServiceInjector.cs
@@ -1,0 +1,14 @@
+﻿namespace MvcTurbine.ComponentModel
+{
+    public class EmptyServiceInjector : IServiceInjector
+    {
+        public TService Inject<TService>(TService instance) where TService : class
+        {
+            return instance;
+        }
+
+        public void TearDown<TService>(TService instance) where TService : class
+        {
+        }
+    }
+}

--- a/src/Engine/MvcTurbine/ComponentModel/EmptyServiceReleaser.cs
+++ b/src/Engine/MvcTurbine/ComponentModel/EmptyServiceReleaser.cs
@@ -1,0 +1,9 @@
+﻿namespace MvcTurbine.ComponentModel
+{
+    public class EmptyServiceReleaser : IServiceReleaser
+    {
+        public void Release(object instance)
+        {
+        }
+    }
+}

--- a/src/Engine/MvcTurbine/MvcTurbine.csproj
+++ b/src/Engine/MvcTurbine/MvcTurbine.csproj
@@ -86,6 +86,8 @@
     <Compile Include="ComponentModel\DefaultAutoRegistrator.cs" />
     <Compile Include="ComponentModel\DefaultBinAssemblyLoader.cs" />
     <Compile Include="ComponentModel\DependencyResolutionException.cs" />
+    <Compile Include="ComponentModel\EmptyServiceInjector.cs" />
+    <Compile Include="ComponentModel\EmptyServiceReleaser.cs" />
     <Compile Include="ComponentModel\ExceptionExtensions.cs" />
     <Compile Include="ComponentModel\IServiceInjector.cs" />
     <Compile Include="ComponentModel\IServiceRegistrar.cs" />


### PR DESCRIPTION
If the service locator does not implement the injector or releaser, use an empty one to prevent failing resolution calls.
