### PR TITLE
Add a comma to the MvcTurbine filters, which will prevent MvcTurbine from

### DIFF
--- a/src/Engine/MvcTurbine/ComponentModel/CommonAssemblyFilter.cs
+++ b/src/Engine/MvcTurbine/ComponentModel/CommonAssemblyFilter.cs
@@ -23,7 +23,7 @@
             AddFilter("mscorlib");
             AddFilter("Microsoft");
 
-            AddFilter("MvcTurbine");
+            AddFilter("MvcTurbine,");
             AddFilter("MvcTurbine.Web");
 
             // Ignore the Visual Studio extra assemblies!


### PR DESCRIPTION
Add a comma to the MvcTurbine filters, which will prevent MvcTurbine from being included but not block out MvcTurbine.*.
