### PR TITLE
Virtual path provider chaining

### DIFF
--- a/src/Blades/EmbeddedViews/MvcTurbine.EmbeddedViews/EmbeddedViewVirtualPathProvider.cs
+++ b/src/Blades/EmbeddedViews/MvcTurbine.EmbeddedViews/EmbeddedViewVirtualPathProvider.cs
@@ -33,21 +33,19 @@ namespace MvcTurbine.EmbeddedViews {
             if (table == null) {
                 throw new ArgumentNullException("table", "EmbeddedViewTable cannot be null.");
             }
-
             embeddedViews = table;
         }
 
         
         private bool IsEmbeddedView(string virtualPath) {
             string checkPath = VirtualPathUtility.ToAppRelative(virtualPath);
-
             return checkPath.StartsWith("~/Views/", StringComparison.InvariantCultureIgnoreCase) 
                    && embeddedViews.ContainsEmbeddedView(checkPath);
         }
 
         public override bool FileExists(string virtualPath) {
             return (IsEmbeddedView(virtualPath) ||
-                    base.FileExists(virtualPath));
+                    Previous.FileExists(virtualPath));
         }
 
         public override VirtualFile GetFile(string virtualPath) {
@@ -55,8 +53,7 @@ namespace MvcTurbine.EmbeddedViews {
                 EmbeddedView embeddedView = embeddedViews.FindEmbeddedView(virtualPath);
                 return new AssemblyResourceFile(embeddedView, virtualPath);
             }
-
-            return base.GetFile(virtualPath);
+            return Previous.GetFile(virtualPath);
         }
 
         public override CacheDependency GetCacheDependency(
@@ -64,7 +61,7 @@ namespace MvcTurbine.EmbeddedViews {
             IEnumerable virtualPathDependencies,
             DateTime utcStart) {
             return IsEmbeddedView(virtualPath) ? null : 
-                base.GetCacheDependency(virtualPath, virtualPathDependencies, utcStart);
+                Previous.GetCacheDependency(virtualPath, virtualPathDependencies, utcStart);
         }
     }
 }


### PR DESCRIPTION
When you register a virtual path provider, it is added to a chain of providers. We should use the Previous property to hand processing off to the previous provider in the chain if the requested path is not handled by our provider. The chain always ends with the default ASP.NET provider, which serves files from the file system.

http://msdn.microsoft.com/en-us/library/system.web.hosting.virtualpathprovider.previous.aspx
