### PR TITLE
Allow System in the name of assemblies scanned for IRouteRegistrators

### DIFF
--- a/src/Engine/MvcTurbine.Tests/ComponentModel/CommonAssemblyFilterTest.cs
+++ b/src/Engine/MvcTurbine.Tests/ComponentModel/CommonAssemblyFilterTest.cs
@@ -80,5 +80,13 @@
             bool result = filter.Match(null);
             Assert.IsFalse(result);
         }
+
+        [Test]
+        public void No_Match_When_Name_Contains_System_But_Doesnt_Start_With_It () {
+           var filter = new CommonAssemblyFilter();
+           
+           bool result = filter.Match("Company.SystemCheck.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
+           Assert.IsFalse(result);
+        }
     }
 }

--- a/src/Engine/MvcTurbine/ComponentModel/AssemblyFilter.cs
+++ b/src/Engine/MvcTurbine/ComponentModel/AssemblyFilter.cs
@@ -1,4 +1,6 @@
-﻿namespace MvcTurbine.ComponentModel {
+﻿using System.Text.RegularExpressions;
+
+namespace MvcTurbine.ComponentModel {
     using System;
     using System.Collections.Generic;
 
@@ -46,7 +48,7 @@
             if (string.IsNullOrEmpty(assemblyName)) return false;
 
             foreach (var filter in Filters) {
-                if (assemblyName.Contains(filter)) {
+                if (Regex.IsMatch(assemblyName, filter)) {
                     return true;
                 }
             }

--- a/src/Engine/MvcTurbine/ComponentModel/CommonAssemblyFilter.cs
+++ b/src/Engine/MvcTurbine/ComponentModel/CommonAssemblyFilter.cs
@@ -19,7 +19,7 @@
         /// Sets the following filters as default, (System, mscorlib, Microsoft, WebDev, CppCodeProvider).
         /// </summary>
         private void AddDefaults() {
-            AddFilter("System");
+            AddFilter("^System");
             AddFilter("System.Web");
             AddFilter("mscorlib");
             AddFilter("Microsoft");


### PR DESCRIPTION
I’ve modified the filters used to restrict the assemblies searched for IRouteRegistrators less exclusive to support assemblies named like “CompanyName.SystemAudit.Web.dll” while still excluding assemblies from Microsoft that start with System.
